### PR TITLE
Move tag quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The beauty of the thing is that no matter the language you work with, if you can
 
 ### Move your tags quickly
 
-You can click on the ▷ symbole to move the current text to the new tag input. You can press enter or simply move another tag to move to add automaticly the first one.
+You can click on the ▷ symbol to move the current text to the new tag input. You can press enter or simply move another tag to add automatically the first one.
 
 ## Stuff left to do :
 - Ability to edit the translation rules in plain text from the option page of the extension

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The beauty of the thing is that no matter the language you work with, if you can
 },
 ```
 
+## Bonus
+
+### Move your tags quickly
+
+You can click on the ▷ symbole to move the current text to the new tag input. You can press enter or simply move another tag to move to add automaticly the first one.
 
 ## Stuff left to do :
 - Ability to edit the translation rules in plain text from the option page of the extension

--- a/src/content.js
+++ b/src/content.js
@@ -12,8 +12,38 @@ function start() {
 
 	addButton();
 
+	addTagsButton();
 }
 
+// Add button to quickly move the tags
+function addTagsButton(){
+	// Query the tags list and the new tag's input
+	var existingTags = document.querySelectorAll('#translate-tags li');
+	var newTagInput = document.querySelector('li.tagit-new input');
+
+	Array.prototype.forEach.call(existingTags, (tag) => {
+
+		// Create a new link for each existing tag
+		// Clicking on the link will update the input field with the curent value
+		((tagElement) => {
+
+			var arrowElement = document.createElement('a');
+			arrowElement.innerText = '▷';
+			arrowElement.href = '#';
+
+			arrowElement.addEventListener("click", (e) => {
+				e.preventDefault();
+
+				newTagInput.value = tag.querySelector('a').innerText;
+				newTagInput.focus(); // just press enter to validate
+			});
+
+			tagElement.appendChild(arrowElement);
+
+		})(tag)
+
+	});
+}
 
 function addButton() {
 
@@ -37,7 +67,7 @@ function runTranslation() {
 
 		// If no selector is specified, run on the entire text
 		const elements = root.querySelectorAll(rule.selector || "body");
-		if(!elements.length) return; 
+		if(!elements.length) return;
 
 		// Check that we have a translation. No point in matching a pattern if we're not able to translate it in the end
 		const translation = rule.translation[locale];


### PR DESCRIPTION
Currently you may duplicate a lot of tag when translating. With this improvement you can add existing tags quickly to the translated page: 

![screen shot 2016-03-05 at 22 47 11](https://cloud.githubusercontent.com/assets/2452791/13551046/3b622ad0-e324-11e5-89cd-6ac619a14fdb.png)
